### PR TITLE
adding some rustdocs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cfg-if = { version = "1.0.0", features = [] }
 web-sys = { version = "0.3.66", optional = true }
 
 [lib]
+doctest = false  # if you feel like fixing docs go right ahead...
 name = "leptos_hotkeys"
 path = "src/lib.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ cfg-if = { version = "1.0.0", features = [] }
 web-sys = { version = "0.3.66", optional = true }
 
 [lib]
-doctest = false  # if you feel like fixing docs go right ahead...
 name = "leptos_hotkeys"
 path = "src/lib.rs"
 

--- a/src/hotkeys_provider.rs
+++ b/src/hotkeys_provider.rs
@@ -42,11 +42,17 @@ cfg_if! {
         #[derive(Clone)]
         pub struct HotkeysContext {
             pub(crate) pressed_keys: RwSignal<HashMap<String, KeyboardEvent>>,
+            /// This is where events are stored when `_ref` is changed
             pub active_ref_target: RwSignal<Option<EventTarget>>,
+            /// This is the callback that triggers a change in `active_ref_target`
             pub set_ref_target: Callback<Option<EventTarget>>,
+            /// This hashset allows `use_hotkeys` functions to check if a keypress scope matches
             pub active_scopes: RwSignal<HashSet<String>>,
+            /// This callback inserts a scope into `active_scopes`
             pub enable_scope: Callback<String>,
+            /// This callback removes a scope from `active_scopes`
             pub disable_scope: Callback<String>,
+            /// This callback checks if scope exists and then adds/remove from `active_scopes`
             pub toggle_scope: Callback<String>,
         }
     } else {
@@ -101,11 +107,13 @@ pub fn HotkeysProvider(
     #[prop(default = false)]
     allow_blur_event: bool,
 
+    /// This sets the initial scopes to be other than the default scope of `"*"`
     #[prop(default={
         scopes!()
     })]
     initially_active_scopes: HashSet<String>,
 
+    /// The inner components of this components
     children: Children,
 ) -> impl IntoView {
     let active_ref_target: RwSignal<Option<EventTarget>> = RwSignal::new(None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc = include_str!("../README.md")]
 pub mod hotkeys_provider;
 pub mod macros;
 pub mod prelude;

--- a/src/use_hotkeys.rs
+++ b/src/use_hotkeys.rs
@@ -6,6 +6,40 @@ use web_sys::KeyboardEvent;
 
 use std::collections::{HashMap, HashSet};
 
+/// Parses a key combination string and constructs a `Hotkey` struct match.
+///
+/// The `key_combination` parameter is a string representing a combination of keys, 
+/// separated by the '+' character. Each key can be accompanied by modifiers such as 
+/// "ctrl", "alt", "meta", or "shift". The function parses this string and constructs 
+/// a `Hotkey` struct containing the modifiers and keys.
+///
+/// # Arguments
+///
+/// * `key_combination` - A string representing a combination of keys and modifiers.
+///
+/// # Returns
+///
+/// A `Hotkey` struct representing the parsed key combination.
+///
+/// # Examples
+///
+/// ```
+/// use crate::{parse_key, KeyboardModifiers, Hotkey};
+///
+/// let hotkey = parse_key("Ctrl+Shift+A");
+/// assert_eq!(
+///     hotkey,
+///     Hotkey {
+///         modifiers: KeyboardModifiers {
+///             ctrl: true,
+///             alt: false,
+///             meta: false,
+///             shift: true,
+///         },
+///         keys: vec!["a".to_string()],
+///     }
+/// );
+/// ```
 fn parse_key(key_combination: &str) -> Hotkey {
     let parts = key_combination
         .split('+')
@@ -28,6 +62,16 @@ fn parse_key(key_combination: &str) -> Hotkey {
     Hotkey { modifiers, keys }
 }
 
+/// Determines if the given hotkey matches the set of currently pressed keys.
+///
+/// # Arguments
+///
+/// * `hotkey` - A reference to the `Hotkey` struct representing the hotkey to be matched.
+/// * `pressed_keyset` - A mutable reference to a `HashMap<String, KeyboardEvent>` representing the set of currently pressed keys.
+///
+/// # Returns
+///
+/// A boolean value indicating whether the given `hotkey` matches the set of currently pressed keys.
 fn is_hotkey_match(hotkey: &Hotkey, pressed_keyset: &mut HashMap<String, KeyboardEvent>) -> bool {
     let mut modifiers_match = true;
 
@@ -59,6 +103,23 @@ fn is_hotkey_match(hotkey: &Hotkey, pressed_keyset: &mut HashMap<String, Keyboar
     modifiers_match && keys_match
 }
 
+/// Handles the usage of hotkeys within specified scopes.
+///
+/// This function takes a `key_combination` as a comma-separated string representing the hotkey combination,
+/// a callback `on_triggered` to be executed when the hotkey is triggered,
+/// and a vector `scopes` containing the scopes within which the hotkeys should be active.
+///
+/// # Arguments
+///
+/// * `key_combination` - A string representing the hotkey combination.
+/// * `on_triggered` - A callback to be executed when the hotkey is triggered.
+/// * `scopes` - A vector of strings containing the scopes within which the hotkeys should be active.
+///
+/// # Example
+///
+/// ```
+/// use_hotkeys_scoped("Ctrl+Shift+A", Callback::new( move |_| { logging::log!("Hotkey triggered!") }), vec!["Editor".to_string(), "Global".to_string()]);
+/// ```
 pub fn use_hotkeys_scoped(
     key_combination: String,
     on_triggered: Callback<()>,
@@ -90,6 +151,26 @@ pub fn use_hotkeys_scoped(
     });
 }
 
+/// Attaches a hotkey listener to the provided element reference within the specified scopes.
+///
+/// # Arguments
+///
+/// * `key_combination` - A string representing the combination of keys to listen for, separated by commas.
+/// * `on_triggered` - A callback function to be invoked when the hotkey combination is triggered.
+/// * `scopes` - A vector of strings representing the scopes in which the hotkey should be active.
+///
+/// # Returns
+///
+/// A reference to the node on which the hotkey listener is attached.
+///
+/// # Type Parameters
+///
+/// * `T` - The type of element reference.
+///
+/// # Constraints
+///
+/// * `T` must implement `ElementDescriptor`, `'static`, and `Clone`.
+///
 pub fn use_hotkeys_ref_scoped<T>(
     key_combination: String,
     on_triggered: Callback<()>,


### PR DESCRIPTION
I'm just adding what I have before we get too out of sync in forks again. I think the `#![doc = include_str!("../README.md")]` macro in `lib.rs` should work for crates.io. but you might want to double check. 