### PR TITLE
feat: remove csr + hydrate flags

### DIFF
--- a/examples/demo/Cargo.toml
+++ b/examples/demo/Cargo.toml
@@ -12,4 +12,4 @@ leptos_meta = "0.6"
 leptos_router = { version = "0.6", features = ["csr"] }
 log = "0.4"
 leptos_theme = "0.1"
-leptos_hotkeys = { path = "../../leptos_hotkeys", features = ["csr"] }
+leptos_hotkeys = { path = "../../leptos_hotkeys" }

--- a/examples/ssr-demo/Cargo.toml
+++ b/examples/ssr-demo/Cargo.toml
@@ -20,18 +20,10 @@ wasm-bindgen = "=0.2.92"
 thiserror = "1"
 tracing = { version = "0.1", optional = true }
 http = "1"
-leptos_hotkeys = { path = "../../leptos_hotkeys", features = [
-    "hydrate",
-    "debug"
-] }
+leptos_hotkeys = { path = "../../leptos_hotkeys", features = ["debug"] }
 
 [features]
-hydrate = [
-    "leptos/hydrate",
-    "leptos_meta/hydrate",
-    "leptos_router/hydrate",
-    "leptos_hotkeys/hydrate",
-]
+hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
 ssr = [
     "dep:axum",
     "dep:tokio",

--- a/leptos_hotkeys/Cargo.toml
+++ b/leptos_hotkeys/Cargo.toml
@@ -6,25 +6,20 @@ description = "A library that declaratively pairs keybindings with callbacks for
 license = "MIT"
 repository = "http://github.com/friendlymatthew/leptos-hotkeys"
 readme = "README.md"
-authors = [
-    "Matthew Kim <matthewkmkim@gmail.com>",
-    "Robert Junkins <roberthenryjunkins@gmail.com>",
-]
+authors = ["Matthew Kim", "Alvaro Mondejar", "Robert Junkins"]
 keywords = ["leptos", "hotkeys", "wasm"]
 
 [dependencies]
 leptos = { version = "0.6.5", features = ["nightly"] }
-wasm-bindgen = { version = "0.2.92", optional = true }
+wasm-bindgen = { version = "0.2.92" }
 log = "0.4.20"
 cfg-if = { version = "1.0.0", features = [] }
-web-sys = { version = "0.3.66", optional = true }
+web-sys = { version = "0.3.66" }
 
 [lib]
 name = "leptos_hotkeys"
 path = "src/lib.rs"
 
 [features]
-hydrate = ["dep:web-sys", "dep:wasm-bindgen"]
-csr = ["dep:web-sys", "dep:wasm-bindgen"]
 debug = []
 ssr = []

--- a/leptos_hotkeys/src/hotkeys_provider.rs
+++ b/leptos_hotkeys/src/hotkeys_provider.rs
@@ -1,32 +1,32 @@
 use leptos::*;
 use std::collections::HashSet;
 
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use std::collections::HashMap;
 
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use leptos::html::ElementDescriptor;
 
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use wasm_bindgen::closure::Closure;
 
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use wasm_bindgen::JsCast;
 
 use crate::types::Hotkey;
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use web_sys::{EventTarget, KeyboardEvent};
 
 // Defining a hotkey context structure
 #[derive(Clone, Copy)]
 pub struct HotkeysContext {
-    #[cfg(any(feature = "hydrate", feature = "csr"))]
+    #[cfg(not(feature = "ssr"))]
     pub(crate) pressed_keys: RwSignal<HashMap<String, KeyboardEvent>>,
 
-    #[cfg(any(feature = "hydrate", feature = "csr"))]
+    #[cfg(not(feature = "ssr"))]
     pub active_ref_target: RwSignal<Option<EventTarget>>,
 
-    #[cfg(any(feature = "hydrate", feature = "csr"))]
+    #[cfg(not(feature = "ssr"))]
     pub set_ref_target: Callback<Option<EventTarget>>,
     pub active_scopes: RwSignal<HashSet<String>>,
     pub enable_scope: Callback<String>,
@@ -42,15 +42,15 @@ pub fn provide_hotkeys_context<T>(
 where
     T: ElementDescriptor + 'static + Clone,
 {
-    #[cfg(any(feature = "hydrate", feature = "csr"))]
+    #[cfg(not(feature = "ssr"))]
     let active_ref_target: RwSignal<Option<EventTarget>> = RwSignal::new(None);
 
-    #[cfg(any(feature = "hydrate", feature = "csr"))]
+    #[cfg(not(feature = "ssr"))]
     let set_ref_target = Callback::new(move |target: Option<EventTarget>| {
         active_ref_target.set(target);
     });
 
-    #[cfg(any(feature = "hydrate", feature = "csr"))]
+    #[cfg(not(feature = "ssr"))]
     let pressed_keys: RwSignal<HashMap<String, KeyboardEvent>> = RwSignal::new(HashMap::new());
 
     let active_scopes: RwSignal<HashSet<String>> = RwSignal::new(initially_active_scopes);
@@ -92,7 +92,7 @@ where
     });
 
     #[cfg(feature = "debug")]
-    if cfg!(any(feature = "hydrate", feature = "csr")) {
+    if cfg!(not(feature = "ssr")) {
         create_effect(move |_| {
             let pressed_keys_list =
                 move || pressed_keys.get().keys().cloned().collect::<Vec<String>>();
@@ -161,13 +161,13 @@ where
     });
 
     let hotkeys_context = HotkeysContext {
-        #[cfg(any(feature = "hydrate", feature = "csr"))]
+        #[cfg(not(feature = "ssr"))]
         pressed_keys,
 
-        #[cfg(any(feature = "hydrate", feature = "csr"))]
+        #[cfg(not(feature = "ssr"))]
         active_ref_target,
 
-        #[cfg(any(feature = "hydrate", feature = "csr"))]
+        #[cfg(not(feature = "ssr"))]
         set_ref_target,
 
         active_scopes,

--- a/leptos_hotkeys/src/use_hotkeys.rs
+++ b/leptos_hotkeys/src/use_hotkeys.rs
@@ -1,18 +1,18 @@
 use crate::hotkeys_provider::use_hotkeys_context;
 use crate::types::Hotkey;
 
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use leptos::{ev::DOMEventResponder, html::ElementDescriptor, *};
 
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use leptos_dom::NodeRef;
 
 use std::collections::{HashMap, HashSet};
 
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use wasm_bindgen::JsValue;
 
-#[cfg(any(feature = "hydrate", feature = "csr"))]
+#[cfg(not(feature = "ssr"))]
 use web_sys::KeyboardEvent;
 
 fn is_hotkey_match(hotkey: &Hotkey, pressed_keyset: &mut HashMap<String, KeyboardEvent>) -> bool {


### PR DESCRIPTION
closes #38 


From Maccesh:

```
It seems you really don't need the hydrate or csr features. You can safely have web-sys and wasm-bindgen as dependencies on the server as long as you don't try and instantiate sth from them
leptos-use only has an ssr feature and then checks if that's set or not
```


This PR also needs to do the following:
- [ ] update readme