### PR TITLE
Publish through CI using GIT tags

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+# Don't compute diff for these files
+Cargo.lock -diff
+dist/** -diff
+
+# Don't export/archive these files
+.github export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,57 @@ jobs:
         run: |
           cd examples/${{ matrix.example }}
           cargo leptos build --release
+
+  test-release-leptos-hotkeys:
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+    name: Test leptos-hotkeys release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: hecrj/setup-rust-action@v2
+      - name: Publish
+        run: |
+          cargo login ${{ secrets.CRATES_TOKEN }}
+          cargo publish -v -p leptos-hotkeys
+
+  release-leptos-hotkeys:
+    if: startsWith(github.ref, 'refs/tags/')
+    name: Release leptos-hotkeys
+    needs:
+      - lint
+      - build-example
+      - test-release-leptos-hotkeys
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: hecrj/setup-rust-action@v2
+      - name: Publish
+        run: |
+          cargo login ${{ secrets.CRATES_TOKEN }}
+          cargo publish -v -p leptos-fluent-macros
+
+  create-release:
+    if: startsWith(github.ref, 'refs/tags/')
+    name: Create release
+    needs: release-leptos-hotkeys
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get tag metadata
+        id: tag
+        run: |
+          TAG_TITLE=${GITHUB_REF#refs/*/}
+          echo "title=$TAG_TITLE" >> $GITHUB_OUTPUT
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ steps.tag.outputs.title }}
+          tag_name: ${{ steps.tag.outputs.title }}
+          body: |
+            See [CHANGELOG](https://github.com/gaucho-labs/leptos-hotkeys/blob/main/CHANGELOG.md).
+          draft: false
+          prerelease: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,8 @@ cargo make format
 
 ## Release
 
-1. Update the *CHANGELOG.md*. Push the changes to the main branch.
+1. Update *CHANGELOG.md* and bump version.
+1. Push the changes to the main branch.
 1. Create a and push GIT tag from latest main branch:
 
 ```sh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,3 +15,15 @@ cargo make lint
 ```sh
 cargo make format
 ```
+
+## Release
+
+1. Update the *CHANGELOG.md*. Push the changes to the main branch.
+1. Create a and push GIT tag from latest main branch:
+
+```sh
+git tag -a v0.1.0 -m ""
+git push origin v0.1.0
+```
+
+> [!NOTE] Change `v0.1.0` to the new version number.


### PR DESCRIPTION
Configures the publication of the crate through CI when pushing GIT tags (closes #59).

@friendlymatthew you need to set a repository action secret `CRATES_TOKEN` with the content of your crates.io token to be able to publish on crates.io on your behalf. Only the updates package permission needs to be enabled.

---

To release v0.2.0 we only need to:

- Update the changelog.
- Update the README: installation instructions and usage.

I think that we can move other milestones beyond v0.2.0 because the current changes are the most prioritaries and there is sufficient breaking changes happening here. I would release an alpha of v0.2.0 with the version `v0.2.0a` and, when we check that all works, release v0.2.0. What do you think?