### PR TITLE
Add write permissions to create-release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
     name: Create release
     needs: release-leptos-hotkeys
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Get tag metadata


### PR DESCRIPTION
Suggested at https://github.com/softprops/action-gh-release/issues/236#issuecomment-1150530128 as the fix for the error on last run at https://github.com/gaucho-labs/leptos-hotkeys/actions/runs/8367979125/job/22911718746