### PR TITLE
Remove prelude and make modules private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased - 0.2.0-alpha.2
+
+### Breaking changes
+
+- Remove `prelude` module.
+- Internal modules are no longer public.
+
 ## _March 21th, 2024_ - 0.2.0-alpha.1
 
 ### Breaking changes

--- a/leptos_hotkeys/src/lib.rs
+++ b/leptos_hotkeys/src/lib.rs
@@ -1,7 +1,8 @@
-pub mod hotkeys_provider;
-pub mod macros;
-pub mod prelude;
-pub mod types;
-pub mod use_hotkeys;
+mod hotkeys_provider;
+mod macros;
+mod types;
+mod use_hotkeys;
 
-pub use prelude::*;
+pub use hotkeys_provider::{provide_hotkeys_context, use_hotkeys_context, HotkeysContext};
+pub use types::{Hotkey, KeyboardModifiers};
+pub use use_hotkeys::{use_hotkeys_ref_scoped, use_hotkeys_scoped};

--- a/leptos_hotkeys/src/prelude.rs
+++ b/leptos_hotkeys/src/prelude.rs
@@ -1,6 +1,0 @@
-pub use crate::hotkeys_provider::{provide_hotkeys_context, use_hotkeys_context, HotkeysContext};
-pub use crate::use_hotkeys::{use_hotkeys_ref_scoped, use_hotkeys_scoped};
-
-// macros
-pub use crate::scopes;
-pub use crate::{use_hotkeys, use_hotkeys_ref};


### PR DESCRIPTION
Closes #83

Note that `#[macro_export]` exports macros publicly through *lib.rs*, so there is no need to publicly export them explicitly. See [_Path-Based scope_ section in _Macros by example_ chapter of the Rust Reference book](https://doc.rust-lang.org/reference/macros-by-example.html#path-based-scope).