### PR TITLE
Use code

### DIFF
--- a/examples/ssr-demo/src/app.rs
+++ b/examples/ssr-demo/src/app.rs
@@ -54,6 +54,10 @@ fn HomePage() -> impl IntoView {
         set_count.update(|c| *c -= 1);
     });
 
+    use_hotkeys!(("space") => move |_| {
+            logging::log!("hola")
+    });
+
     let div_ref = create_node_ref::<html::Div>();
 
     use_hotkeys_ref!((div_ref, "5") => move |_| {

--- a/leptos_hotkeys/src/context.rs
+++ b/leptos_hotkeys/src/context.rs
@@ -98,13 +98,13 @@ where
         let keydown_listener =
             wasm_bindgen::closure::Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
                 pressed_keys.update(|keys| {
-                    keys.insert(event.key().to_lowercase(), event);
+                    keys.insert(event.code().to_lowercase(), event);
                 });
             }) as Box<dyn Fn(_)>);
         let keyup_listener =
             wasm_bindgen::closure::Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
                 pressed_keys.update(|keys| {
-                    keys.remove(&event.key().to_lowercase());
+                    keys.remove(&event.code().to_lowercase());
                 });
             }) as Box<dyn Fn(_)>);
 


### PR DESCRIPTION
We should use the `code` attribute. https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code

A later update should be the ability to add both, maybe create mappings between types. 

