### PR TITLE
add hotkeys option

### DIFF
--- a/examples/demo/src/app.rs
+++ b/examples/demo/src/app.rs
@@ -20,7 +20,7 @@ pub fn Button(href: &'static str, children: Children) -> impl IntoView {
 pub fn App() -> impl IntoView {
     provide_meta_context();
     let main_ref = create_node_ref::<html::Main>();
-    provide_hotkeys_context(main_ref, false, scopes!("scope_a"));
+    provide_hotkeys_context(main_ref);
 
     view! {
         <Stylesheet id="leptos" href="/pkg/demo.css"/>

--- a/examples/ssr-demo/src/app.rs
+++ b/examples/ssr-demo/src/app.rs
@@ -1,7 +1,7 @@
 use crate::error_template::{AppError, ErrorTemplate};
 use leptos::*;
 use leptos_hotkeys::{
-    provide_hotkeys_context, scopes, use_hotkeys, use_hotkeys_ref, HotkeysContext,
+    provide_hotkeys_context, use_hotkeys, use_hotkeys_ref, HotkeysContext,
 };
 use leptos_meta::*;
 use leptos_router::*;
@@ -13,7 +13,7 @@ pub fn App() -> impl IntoView {
 
     let main_ref = create_node_ref::<leptos::html::Main>();
 
-    let HotkeysContext { .. } = provide_hotkeys_context(main_ref, false, scopes!());
+    let HotkeysContext { .. } = provide_hotkeys_context(main_ref);
 
     view! {
         <Stylesheet id="leptos" href="/pkg/ssr-demo.css"/>

--- a/leptos_hotkeys/src/context.rs
+++ b/leptos_hotkeys/src/context.rs
@@ -3,6 +3,7 @@ use leptos::*;
 use std::collections::HashSet;
 #[cfg(not(feature = "ssr"))]
 use wasm_bindgen::JsCast;
+use crate::scopes;
 
 // Defining a hotkey context structure
 #[derive(Clone, Copy)]
@@ -22,7 +23,17 @@ pub struct HotkeysContext {
     pub toggle_scope: Callback<String>,
 }
 
+
 pub fn provide_hotkeys_context<T>(
+    #[cfg_attr(feature = "ssr", allow(unused_variables))] node_ref: NodeRef<T>
+) -> HotkeysContext
+where
+T: ElementDescriptor + 'static + Clone,
+{
+    provide_hotkeys_context_option(node_ref, false, scopes!())
+}
+
+fn provide_hotkeys_context_option<T>(
     #[cfg_attr(feature = "ssr", allow(unused_variables))] node_ref: NodeRef<T>,
     #[cfg_attr(feature = "ssr", allow(unused_variables))] allow_blur_event: bool,
     initially_active_scopes: HashSet<String>,


### PR DESCRIPTION
#84

Adds middle layer to the `provide_hotkeys` scheme.

Note, I didn't do the options with the derived `Builder` trait like Mr. leptos-use, but I plan on doing that but have some questions