### PR TITLE
Alternative keyboard layout works. Detects the space key.

### DIFF
--- a/leptos_hotkeys/src/context.rs
+++ b/leptos_hotkeys/src/context.rs
@@ -97,13 +97,13 @@ where
         let keydown_listener =
             wasm_bindgen::closure::Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
                 pressed_keys.update(|keys| {
-                    keys.insert(event.code().to_lowercase(), event);
+                    keys.insert(event.key().to_lowercase(), event);
                 });
             }) as Box<dyn Fn(_)>);
         let keyup_listener =
             wasm_bindgen::closure::Closure::wrap(Box::new(move |event: web_sys::KeyboardEvent| {
                 pressed_keys.update(|keys| {
-                    keys.remove(&event.code().to_lowercase());
+                    keys.remove(&event.key().to_lowercase());
                 });
             }) as Box<dyn Fn(_)>);
 

--- a/leptos_hotkeys/src/hotkey.rs
+++ b/leptos_hotkeys/src/hotkey.rs
@@ -84,22 +84,33 @@ pub(crate) fn is_hotkey_match(
 
     if hotkey.modifiers.ctrl {
         modifiers_match &= pressed_keyset.contains_key("controlleft")
-            || pressed_keyset.contains_key("controlright") || pressed_keyset.contains_key("control");
+            || pressed_keyset.contains_key("controlright") 
+            || pressed_keyset.contains_key("control");
     }
 
     if hotkey.modifiers.shift {
         modifiers_match &=
-            pressed_keyset.contains_key("shiftleft") || pressed_keyset.contains_key("shiftright") || pressed_keyset.contains_key("shift");
+            pressed_keyset.contains_key("shiftleft") 
+            || pressed_keyset.contains_key("shiftright") 
+            || pressed_keyset.contains_key("shift");
     }
 
     if hotkey.modifiers.meta {
         modifiers_match &=
-            pressed_keyset.contains_key("metaleft") || pressed_keyset.contains_key("metaright") || pressed_keyset.contains_key("meta") || pressed_keyset.contains_key("command") || pressed_keyset.contains_key("cmd") || pressed_keyset.contains_key("super") || pressed_keyset.contains_key("win");
+            pressed_keyset.contains_key("metaleft") 
+            || pressed_keyset.contains_key("metaright") 
+            || pressed_keyset.contains_key("meta") 
+            || pressed_keyset.contains_key("command") 
+            || pressed_keyset.contains_key("cmd") 
+            || pressed_keyset.contains_key("super") 
+            || pressed_keyset.contains_key("win");
     }
 
     if hotkey.modifiers.alt {
         modifiers_match &=
-            pressed_keyset.contains_key("altleft") || pressed_keyset.contains_key("altright") || pressed_keyset.contains_key("alt");
+            pressed_keyset.contains_key("altleft") 
+            || pressed_keyset.contains_key("altright") 
+            || pressed_keyset.contains_key("alt");
     }
 
     if modifiers_match {

--- a/leptos_hotkeys/src/hotkey.rs
+++ b/leptos_hotkeys/src/hotkey.rs
@@ -37,7 +37,7 @@ impl FromStr for Hotkey {
     fn from_str(key_combination: &str) -> Result<Self, Self::Err> {
         let parts = key_combination
             .split('+')
-            .map(|v| if v == " " {v} else {v.trim()})
+            .map(|v| if v == " " { v } else { v.trim() })
             .collect::<Vec<&str>>();
 
         let mut modifiers = KeyboardModifiers::default();

--- a/leptos_hotkeys/src/hotkey.rs
+++ b/leptos_hotkeys/src/hotkey.rs
@@ -37,7 +37,7 @@ impl FromStr for Hotkey {
     fn from_str(key_combination: &str) -> Result<Self, Self::Err> {
         let parts = key_combination
             .split('+')
-            .map(str::trim)
+            .map(|v| if v == " " {v} else {v.trim()})
             .collect::<Vec<&str>>();
 
         let mut modifiers = KeyboardModifiers::default();
@@ -84,22 +84,22 @@ pub(crate) fn is_hotkey_match(
 
     if hotkey.modifiers.ctrl {
         modifiers_match &= pressed_keyset.contains_key("controlleft")
-            || pressed_keyset.contains_key("controlright");
+            || pressed_keyset.contains_key("controlright") || pressed_keyset.contains_key("control");
     }
 
     if hotkey.modifiers.shift {
         modifiers_match &=
-            pressed_keyset.contains_key("shiftleft") || pressed_keyset.contains_key("shiftright");
+            pressed_keyset.contains_key("shiftleft") || pressed_keyset.contains_key("shiftright") || pressed_keyset.contains_key("shift");
     }
 
     if hotkey.modifiers.meta {
         modifiers_match &=
-            pressed_keyset.contains_key("metaleft") || pressed_keyset.contains_key("metaright");
+            pressed_keyset.contains_key("metaleft") || pressed_keyset.contains_key("metaright") || pressed_keyset.contains_key("meta") || pressed_keyset.contains_key("command") || pressed_keyset.contains_key("cmd") || pressed_keyset.contains_key("super") || pressed_keyset.contains_key("win");
     }
 
     if hotkey.modifiers.alt {
         modifiers_match &=
-            pressed_keyset.contains_key("altleft") || pressed_keyset.contains_key("altright");
+            pressed_keyset.contains_key("altleft") || pressed_keyset.contains_key("altright") || pressed_keyset.contains_key("alt");
     }
 
     if modifiers_match {

--- a/leptos_hotkeys/src/hotkey.rs
+++ b/leptos_hotkeys/src/hotkey.rs
@@ -84,32 +84,29 @@ pub(crate) fn is_hotkey_match(
 
     if hotkey.modifiers.ctrl {
         modifiers_match &= pressed_keyset.contains_key("controlleft")
-            || pressed_keyset.contains_key("controlright") 
+            || pressed_keyset.contains_key("controlright")
             || pressed_keyset.contains_key("control");
     }
 
     if hotkey.modifiers.shift {
-        modifiers_match &=
-            pressed_keyset.contains_key("shiftleft") 
-            || pressed_keyset.contains_key("shiftright") 
+        modifiers_match &= pressed_keyset.contains_key("shiftleft")
+            || pressed_keyset.contains_key("shiftright")
             || pressed_keyset.contains_key("shift");
     }
 
     if hotkey.modifiers.meta {
-        modifiers_match &=
-            pressed_keyset.contains_key("metaleft") 
-            || pressed_keyset.contains_key("metaright") 
-            || pressed_keyset.contains_key("meta") 
-            || pressed_keyset.contains_key("command") 
-            || pressed_keyset.contains_key("cmd") 
-            || pressed_keyset.contains_key("super") 
+        modifiers_match &= pressed_keyset.contains_key("metaleft")
+            || pressed_keyset.contains_key("metaright")
+            || pressed_keyset.contains_key("meta")
+            || pressed_keyset.contains_key("command")
+            || pressed_keyset.contains_key("cmd")
+            || pressed_keyset.contains_key("super")
             || pressed_keyset.contains_key("win");
     }
 
     if hotkey.modifiers.alt {
-        modifiers_match &=
-            pressed_keyset.contains_key("altleft") 
-            || pressed_keyset.contains_key("altright") 
+        modifiers_match &= pressed_keyset.contains_key("altleft")
+            || pressed_keyset.contains_key("altright")
             || pressed_keyset.contains_key("alt");
     }
 


### PR DESCRIPTION
Changed from .code() to .keys() so that alternative keyboard layouts are correctly detected. 

Made str::trim to run conditionally so that the space key is detected.