### PR TITLE
Fix hotkeys matching

### DIFF
--- a/leptos_hotkeys/src/hotkey.rs
+++ b/leptos_hotkeys/src/hotkey.rs
@@ -98,32 +98,44 @@ pub(crate) fn is_hotkey_match(
 ) -> bool {
     let mut modifiers_match = true;
 
+    let is_ctrl_pressed = pressed_keyset.contains_key("controlleft")
+        || pressed_keyset.contains_key("controlright")
+        || pressed_keyset.contains_key("control");
     if hotkey.modifiers.ctrl {
-        modifiers_match &= pressed_keyset.contains_key("controlleft")
-            || pressed_keyset.contains_key("controlright")
-            || pressed_keyset.contains_key("control");
+        modifiers_match &= is_ctrl_pressed;
+    } else {
+        modifiers_match &= !is_ctrl_pressed;
     }
 
+    let is_shift_pressed = pressed_keyset.contains_key("shiftleft")
+        || pressed_keyset.contains_key("shiftright")
+        || pressed_keyset.contains_key("shift");
     if hotkey.modifiers.shift {
-        modifiers_match &= pressed_keyset.contains_key("shiftleft")
-            || pressed_keyset.contains_key("shiftright")
-            || pressed_keyset.contains_key("shift");
+        modifiers_match &= is_shift_pressed;
+    } else {
+        modifiers_match &= !is_shift_pressed;
     }
 
+    let is_meta_pressed = pressed_keyset.contains_key("metaleft")
+        || pressed_keyset.contains_key("metaright")
+        || pressed_keyset.contains_key("meta")
+        || pressed_keyset.contains_key("command")
+        || pressed_keyset.contains_key("cmd")
+        || pressed_keyset.contains_key("super")
+        || pressed_keyset.contains_key("win");
     if hotkey.modifiers.meta {
-        modifiers_match &= pressed_keyset.contains_key("metaleft")
-            || pressed_keyset.contains_key("metaright")
-            || pressed_keyset.contains_key("meta")
-            || pressed_keyset.contains_key("command")
-            || pressed_keyset.contains_key("cmd")
-            || pressed_keyset.contains_key("super")
-            || pressed_keyset.contains_key("win");
+        modifiers_match &= is_meta_pressed;
+    } else {
+        modifiers_match &= !is_meta_pressed;
     }
 
+    let is_alt_pressed = pressed_keyset.contains_key("altleft")
+        || pressed_keyset.contains_key("altright")
+        || pressed_keyset.contains_key("alt");
     if hotkey.modifiers.alt {
-        modifiers_match &= pressed_keyset.contains_key("altleft")
-            || pressed_keyset.contains_key("altright")
-            || pressed_keyset.contains_key("alt");
+        modifiers_match &= is_alt_pressed;
+    } else {
+        modifiers_match &= !is_alt_pressed;
     }
 
     if modifiers_match {


### PR DESCRIPTION
Hi,
Thank you for such a great library! I'm using it in my project and am happy with the functionality. It has everything I need.

Unfortunately, I've faced a bug in the hotkeys matching algorithm: it doesn't check that the controls aren't pressed when they're not needed. Let me give you an example to explain the situation better.

Suppose I want to do some action on the `ctrl+m` hotkey. The action will be executed even on `ctrl+shift+m` or `ctrl+alt+m`. It doesn't seem correct, because I may want to set another action on the `ctrl+shift+m` hotkey. The most common case is when the user wants to add hotkeys for scrolling: `ctrl+tab` is next and `ctrl+shift+tab` is prev.

In this PR, I've fixed this bug by checking if the modifier key is not pressed when it doesn't need to be pressed.